### PR TITLE
Create LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 Syoyo Fujita
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
This library is an awesome project, and I can imagine a lot of 3D application written in C++ would happily use it to load glTF assets ;-)

However, the license wasn't properly stated on the project. To actually put work under the term of the MIT license agreement, a copyright notice **needs** to be distributed alongside the source code.

It is also standard practice to add a warranty disclaimer. This prevent people to hold you liable if (at least they think) something doesn't work because of this library.

I took the liberty to put the file in place, with your full name as stated on your GitHub profile as the copyright holder. This is the text that states that you, the author, grants the to other people to use this as a free/open-source software, with all the thing that comes with it (access to source code, right to modify, redistribute, redistribute modified version, and use for any purpose they like) 

Sorry for the annoyance ^^"